### PR TITLE
#54 ID 入力時に先頭小文字にする

### DIFF
--- a/src/components/DirectInputModal.tsx
+++ b/src/components/DirectInputModal.tsx
@@ -37,6 +37,7 @@ const DirectInputModal: React.FC<{
         <TextField
           autoFocus
           margin="dense"
+          type="email"
           label={`${props.type === "rsv" ? "予約" : "ゲスト"} ID`}
           defaultValue={props.currentId}
           onChange={(event) => {

--- a/src/components/DirectInputModal.tsx
+++ b/src/components/DirectInputModal.tsx
@@ -37,7 +37,6 @@ const DirectInputModal: React.FC<{
         <TextField
           autoFocus
           margin="dense"
-          type="email"
           label={`${props.type === "rsv" ? "予約" : "ゲスト"} ID`}
           defaultValue={props.currentId}
           onChange={(event) => {

--- a/src/components/DirectInputModal.tsx
+++ b/src/components/DirectInputModal.tsx
@@ -45,6 +45,9 @@ const DirectInputModal: React.FC<{
           fullWidth
           placeholder={props.type === "rsv" ? "R-00000-00000" : "GX-00000"}
           color="secondary"
+          inputProps={{
+            autocapitalize: "off",
+          }}
         />
       </DialogContent>
       <DialogActions>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -102,6 +102,7 @@ const Login: React.FC = () => {
             </FormGroup>
             <TextField
               label="ID"
+              type="email"
               value={id}
               onChange={(e) => {
                 setId(e.target.value);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -109,6 +109,9 @@ const Login: React.FC = () => {
               className={classes.mb}
               fullWidth={true}
               error={isError}
+              inputProps={{
+                autocapitalize: "off",
+              }}
             />
             <TextField
               label="パスワード"

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -108,6 +108,7 @@ const Login: React.FC = () => {
               }}
               className={classes.mb}
               fullWidth={true}
+              color="secondary"
               error={isError}
               inputProps={{
                 autocapitalize: "off",
@@ -121,6 +122,7 @@ const Login: React.FC = () => {
                 setPassword(e.target.value);
               }}
               fullWidth={true}
+              color="secondary"
               error={isError}
             />
           </CardContent>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -102,7 +102,6 @@ const Login: React.FC = () => {
             </FormGroup>
             <TextField
               label="ID"
-              type="email"
               value={id}
               onChange={(e) => {
                 setId(e.target.value);


### PR DESCRIPTION
fix #54

`type="email"` は半角英数字キーボードを出すため

- fix: add autocapitalize attr
- fix: color of login text field
- fix: set text type to email
