### PR TITLE
#60 レイアウトの高さが余分に高かった

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -10,7 +10,3 @@ body {
   width: 100vw;
   overscroll-behavior: none;
 }
-
-#root {
-  height: 100%;
-}

--- a/src/layouts/Main.tsx
+++ b/src/layouts/Main.tsx
@@ -9,7 +9,10 @@ import { AuthContext } from "libs/auth";
 const useStyles = makeStyles((theme) =>
   createStyles({
     root: {
-      height: "calc(var(--100vh, 100vh) + env(safe-area-inset-top, 0))",
+      height: "var(--100vh, 0px)",
+      "@media screen and (display-mode: standalone)": {
+        height: "100vh",
+      },
       width: "100vw",
       overflowY: "scroll",
       overscrollBehavior: "none",


### PR DESCRIPTION
fix #60

iOS PWA にて、`window.innerHeight` がおかしい（top safe area の高さを含まない）ので、dynamic 100vh + safe area を使用していた
しかしながら、ときどき正しい高さが返ってくることがあり、そのとき safe area の分だけ余分になってしまっていた

css 100vh を使用するとブラウザで正しくスクロールできなくなってしまうので、`display-mode` が `standalone` であるかをメディアクエリで判別する形とした

これで正しく動いてほしい。

## 検証済みデバイス

- iOS Simulator
  - iOS 11 Pro (PWA / safari)
  - iPhone SE2 (PWA / safari)
- Huawei P20 Pro (PWA / chrome)

