### PR TITLE
#78 でざいんりにゅーある

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "axios": "^0.21.1",
+    "chroma-js": "^2.1.2",
     "classnames": "^2.2.6",
     "clsx": "^1.1.1",
     "moment": "^2.29.1",
@@ -42,6 +43,7 @@
     "ua-parser-js": "^0.7.27"
   },
   "devDependencies": {
+    "@types/chroma-js": "^2.1.3",
     "@types/gtag.js": "^0.0.4",
     "@types/node": "^14.14.34",
     "@types/react": "^17.0.11",

--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon-180.png">
     <meta name="apple-mobile-web-app-title" content="CAPPUCCINO">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="theme-color" content="#457fb3" />
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=%REACT_APP_GA_ID%"></script>

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -5,7 +5,7 @@
 
 body {
   margin: 0;
-  background: #457fb3;
+  //background: #457fb3;
   height: 100%;
   width: 100vw;
   overscroll-behavior: none;

--- a/src/assets/styles/theme.ts
+++ b/src/assets/styles/theme.ts
@@ -21,8 +21,8 @@ const darkPalette: PaletteOptions = {
   afesDark,
   afesLight,
   background: {
-    default: "#202125",
-    paper: "#2d2e32",
+    default: "#000000",
+    paper: "#1c1c1d",
   },
 };
 

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -54,7 +54,7 @@ const BottomNav: React.VFC<{ className?: string }> = ({ className }) => {
   }, [history.location.pathname]);
 
   return (
-    <Paper elevation={6} className={clsx(classes.root, className)}>
+    <Paper elevation={3} className={clsx(classes.root, className)}>
       <BottomNavigation
         value={value}
         onChange={(event, newValue) => {

--- a/src/components/ExhInfoCard.tsx
+++ b/src/components/ExhInfoCard.tsx
@@ -1,0 +1,55 @@
+import React, { useContext, useEffect, useState } from "react";
+import { Card, Typography } from "@material-ui/core";
+import { Skeleton } from "@material-ui/lab";
+import { createStyles, makeStyles } from "@material-ui/core/styles";
+import { AuthContext } from "libs/auth";
+import api, { ExhibitionStatus } from "@afes-website/docs";
+import aspida from "@aspida/axios";
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    root: {
+      padding: theme.spacing(2),
+    },
+    title: {
+      marginBottom: theme.spacing(1.5),
+    },
+  })
+);
+
+const ExhInfoCard: React.VFC = () => {
+  const auth = useContext(AuthContext).val;
+  const classes = useStyles();
+
+  const [exhInfo, setExhInfo] = useState<ExhibitionStatus | null>(null);
+
+  const getExhInfo = () => {
+    const user = auth.get_current_user();
+    if (!user || !user.permissions.exhibition) return;
+    api(aspida())
+      .exhibitions._id(user.id)
+      .$get({ headers: { Authorization: "bearer " + user.token } })
+      .then((_exhInfo) => {
+        setExhInfo(_exhInfo);
+      });
+  };
+
+  useEffect(getExhInfo, [auth]);
+
+  return (
+    <Card className={classes.root}>
+      <Typography variant="h5" component="h2" className={classes.title}>
+        {exhInfo ? exhInfo.info.name : <Skeleton />}
+      </Typography>
+      <Typography variant="body2">
+        {exhInfo ? (
+          `${exhInfo.info.room_id} ･ @${auth.get_current_user_id()}`
+        ) : (
+          <Skeleton />
+        )}
+      </Typography>
+    </Card>
+  );
+};
+
+export default ExhInfoCard;

--- a/src/components/GuestScan.tsx
+++ b/src/components/GuestScan.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   Card,
   CardContent,
@@ -18,7 +18,7 @@ import DirectInputModal from "components/DirectInputModal";
 import DirectInputFab from "components/DirectInputFab";
 import ResultChip, { ResultChipRefs } from "components/ResultChip";
 import ErrorDialog from "components/ErrorDialog";
-import { AuthContext } from "libs/auth";
+import ExhInfoCard from "components/ExhInfoCard";
 import useErrorHandler from "libs/errorHandler";
 import { StatusColor } from "types/statusColor";
 import clsx from "clsx";
@@ -67,18 +67,16 @@ interface Props {
 
 const GuestScan: React.VFC<Props> = (props) => {
   const classes = useStyles();
-  const auth = useContext(AuthContext).val;
   const resultChipRef = useRef<ResultChipRefs>(null);
 
   const [latestGuestId, setLatestGuestId] = useState("");
   const [opensGuestInputModal, setOpensGuestInputModal] = useState(false);
   const [checkStatus, setCheckStatus] = useState<StatusColor | null>(null);
-  const [exhibitionName, setExhibitionName] = useState<string | null>(null);
 
   // エラー処理
   const [errorMessage, errorDialog, , setError] = useErrorHandler();
 
-  const isExh = props.page.split("/")[0] === "exh";
+  const isExh = props.page.split("/")[0] === "exhibition";
 
   const actionName = ((): string => {
     switch (props.page) {
@@ -90,10 +88,6 @@ const GuestScan: React.VFC<Props> = (props) => {
         return "退場";
     }
   })();
-
-  useEffect(() => {
-    if (isExh) setExhibitionName(auth.get_current_user()?.name || "-");
-  }, [setExhibitionName, auth, isExh]);
 
   const handleGuestIdScan = (guestId: string | null) => {
     if (guestId && guestId !== latestGuestId && checkStatus !== "loading") {
@@ -140,13 +134,6 @@ const GuestScan: React.VFC<Props> = (props) => {
   return (
     <div>
       <CardList className={classes.list}>
-        {/* 展示名 */}
-        {isExh && (
-          <Card>
-            <Alert severity="info">{`展示名: ${exhibitionName}`}</Alert>
-          </Card>
-        )}
-
         {/* QR Scanner */}
         <Card>
           <CardContent
@@ -194,6 +181,8 @@ const GuestScan: React.VFC<Props> = (props) => {
             </List>
           </CardContent>
         </Card>
+
+        {isExh && <ExhInfoCard />}
       </CardList>
 
       {/* 直接入力ボタン */}

--- a/src/components/StayStatus.tsx
+++ b/src/components/StayStatus.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles(() =>
     main: {
       display: "flex",
       position: "relative",
-      justifyContent: "space-between",
+      justifyContent: "space-around",
       alignItems: "center",
     },
     termList: {

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -27,7 +27,6 @@ const useStyles = makeStyles((theme) =>
     appBar: {
       paddingTop: "env(safe-area-inset-top)",
       color: theme.palette.text.primary,
-      borderBottom: "1px solid",
     },
     menuIcon: {
       position: "absolute",
@@ -79,7 +78,7 @@ const TopBar: React.VFC<Props> = ({ title, scrollTop, className }) => {
     <div className={clsx(classes.root, className)}>
       <AppBar
         position="static"
-        elevation={0}
+        elevation={scrollTop < 100 ? Math.ceil((scrollTop / 100) * 3) : 3}
         className={classes.appBar}
         style={{
           background: chroma
@@ -88,9 +87,6 @@ const TopBar: React.VFC<Props> = ({ title, scrollTop, className }) => {
               theme.palette.background.paper,
               scrollTop < 100 ? scrollTop / 100 : 1.0
             )
-            .hex(),
-          borderColor: chroma(theme.palette.divider)
-            .alpha(scrollTop < 100 ? (scrollTop / 100) * 0.12 : 0.12)
             .hex(),
         }}
       >

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -70,7 +70,7 @@ const TopBar: React.VFC<Props> = ({ title, className }) => {
 
   return (
     <div className={clsx(classes.root, className)}>
-      <AppBar position="static" className={classes.appBar}>
+      <AppBar position="static" elevation={3} className={classes.appBar}>
         <Toolbar>
           {(auth.get_current_user_id() ||
             routes.Terms.route.create({}) === history.location.pathname) &&

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -6,6 +6,8 @@ import {
   IconButton,
   createStyles,
   makeStyles,
+  useTheme,
+  Theme,
 } from "@material-ui/core";
 import { ArrowBack, ArrowBackIos } from "@material-ui/icons";
 import { useHistory } from "react-router-dom";
@@ -14,15 +16,18 @@ import AccountDrawer from "components/AccountDrawer";
 import { AuthContext } from "libs/auth";
 import routes from "libs/routes";
 import clsx from "clsx";
+import chroma from "chroma-js";
 import UAParser from "ua-parser-js";
 
-const useStyles = makeStyles(() =>
+const useStyles = makeStyles((theme) =>
   createStyles({
     root: {
       flexGrow: 1,
     },
     appBar: {
       paddingTop: "env(safe-area-inset-top)",
+      color: theme.palette.text.primary,
+      borderBottom: "1px solid",
     },
     menuIcon: {
       position: "absolute",
@@ -42,10 +47,11 @@ const useStyles = makeStyles(() =>
 
 interface Props {
   title: string;
+  scrollTop: number;
   className?: string;
 }
 
-const TopBar: React.VFC<Props> = ({ title, className }) => {
+const TopBar: React.VFC<Props> = ({ title, scrollTop, className }) => {
   const classes = useStyles();
   const history = useHistory();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -53,6 +59,7 @@ const TopBar: React.VFC<Props> = ({ title, className }) => {
     history.location.pathname !== "/"
   );
   const auth = useContext(AuthContext).val;
+  const theme = useTheme<Theme>();
 
   const isApple = useMemo(() => {
     const parser = new UAParser(navigator.userAgent);
@@ -70,7 +77,23 @@ const TopBar: React.VFC<Props> = ({ title, className }) => {
 
   return (
     <div className={clsx(classes.root, className)}>
-      <AppBar position="static" elevation={3} className={classes.appBar}>
+      <AppBar
+        position="static"
+        elevation={0}
+        className={classes.appBar}
+        style={{
+          background: chroma
+            .mix(
+              theme.palette.background.default,
+              theme.palette.background.paper,
+              scrollTop < 100 ? scrollTop / 100 : 1.0
+            )
+            .hex(),
+          borderColor: chroma(theme.palette.divider)
+            .alpha(scrollTop < 100 ? (scrollTop / 100) * 0.12 : 0.12)
+            .hex(),
+        }}
+      >
         <Toolbar>
           {(auth.get_current_user_id() ||
             routes.Terms.route.create({}) === history.location.pathname) &&

--- a/src/layouts/Main.tsx
+++ b/src/layouts/Main.tsx
@@ -1,4 +1,10 @@
-import React, { PropsWithChildren, useContext } from "react";
+import React, {
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { createStyles, makeStyles, Paper } from "@material-ui/core";
 import TopBar from "components/TopBar";
 import BottomNav from "components/BottomNav";
@@ -45,9 +51,29 @@ const MainLayout: React.VFC<PropsWithChildren<unknown>> = ({ children }) => {
   const titleCtx = useTitleContext();
   const auth = useContext(AuthContext).val;
 
+  const [scrollTop, setScrollTop] = useState(0);
+  const root = useRef<HTMLDivElement>(null);
+
+  const onScroll = () => {
+    setScrollTop(root.current ? root.current.scrollTop : 0);
+  };
+
+  useEffect(() => {
+    const ref = root.current;
+    if (!ref) return;
+    ref.addEventListener("scroll", onScroll);
+    return () => {
+      ref.removeEventListener("scroll", onScroll);
+    };
+  }, []);
+
   return (
-    <Paper className={classes.root} square={true}>
-      <TopBar title={titleCtx.title} className={classes.topBar} />
+    <Paper className={classes.root} square={true} ref={root}>
+      <TopBar
+        title={titleCtx.title}
+        scrollTop={scrollTop}
+        className={classes.topBar}
+      />
       <main className={classes.main}>{children}</main>
       {auth.get_current_user_id() && (
         <BottomNav className={classes.bottomNav} />

--- a/src/layouts/Main.tsx
+++ b/src/layouts/Main.tsx
@@ -22,9 +22,6 @@ const useStyles = makeStyles((theme) =>
   createStyles({
     root: {
       height: "var(--100vh, 0px)",
-      "@media screen and (display-mode: standalone)": {
-        height: "100vh",
-      },
       width: "100vw",
       overflowY: "scroll",
       overscrollBehavior: "none",

--- a/src/layouts/Main.tsx
+++ b/src/layouts/Main.tsx
@@ -5,7 +5,13 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { createStyles, makeStyles, Paper } from "@material-ui/core";
+import {
+  createStyles,
+  makeStyles,
+  Paper,
+  Theme,
+  useTheme,
+} from "@material-ui/core";
 import TopBar from "components/TopBar";
 import BottomNav from "components/BottomNav";
 import { useTitleContext } from "libs/title";
@@ -50,6 +56,7 @@ const MainLayout: React.VFC<PropsWithChildren<unknown>> = ({ children }) => {
   const classes = useStyles();
   const titleCtx = useTitleContext();
   const auth = useContext(AuthContext).val;
+  const theme = useTheme<Theme>();
 
   const [scrollTop, setScrollTop] = useState(0);
   const root = useRef<HTMLDivElement>(null);
@@ -66,6 +73,10 @@ const MainLayout: React.VFC<PropsWithChildren<unknown>> = ({ children }) => {
       ref.removeEventListener("scroll", onScroll);
     };
   }, []);
+
+  useEffect(() => {
+    document.body.style.background = theme.palette.background.default;
+  }, [theme.palette.background.default, theme.palette.type]);
 
   return (
     <Paper className={classes.root} square={true} ref={root}>

--- a/src/libs/themeMode.ts
+++ b/src/libs/themeMode.ts
@@ -34,7 +34,10 @@ export const ThemeCtx = {
 
 export const useTheme = (): [Theme, () => void] => {
   const [mode, setMode] = useState<ThemeMode>(
-    getThemeModeFromLocalStorage() || "light"
+    getThemeModeFromLocalStorage() ||
+      (window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light")
   );
 
   const theme: Theme = useMemo(() => createMuiTheme(themeOptions[mode]), [

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import HomeCard from "components/HomeCard";
 import CardList from "components/CardList";
 import PwaAlertCard from "components/PwaAlertCard";
 import { GeneralStatusCard, ExhStatusCard } from "components/StayStatusCard";
+import ExhInfoCard from "components/ExhInfoCard";
 import { useTitleSet } from "libs/title";
 import { AuthContext, verifyPermission } from "libs/auth";
 
@@ -32,6 +33,7 @@ const Home: React.VFC = () => {
       )}
       {verifyPermission("exhibition", auth) && (
         <>
+          <ExhInfoCard />
           <ExhStatusCard />
           <HomeCard
             title="展示教室 入退室 QRスキャン"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -32,6 +32,7 @@ const Home: React.VFC = () => {
       )}
       {verifyPermission("exhibition", auth) && (
         <>
+          <ExhStatusCard />
           <HomeCard
             title="展示教室 入退室 QRスキャン"
             paragraphs={[
@@ -43,7 +44,6 @@ const Home: React.VFC = () => {
               ["退室スキャン", routes.ExitScan.route.create({})],
             ]}
           />
-          <ExhStatusCard />
           <HomeCard
             title="入退室スキャン履歴"
             paragraphs={["自展示の入退室履歴をすべて表示します。"]}

--- a/src/pages/executive/CheckInScan.tsx
+++ b/src/pages/executive/CheckInScan.tsx
@@ -405,16 +405,16 @@ const CheckInScan: React.VFC = () => {
           </CardContent>
         </Card>
 
-        {/* はじめからやり直すボタン */}
+        {/* 中断して最初からやり直すボタン */}
         {(activeScanner !== "rsv" || totalCheckStatus === "error") && (
           <Button
-            variant="contained"
-            color="primary"
+            variant="text"
+            color="secondary"
             className={classes.bottomButton}
             startIcon={<Replay />}
             onClick={clearAll}
           >
-            はじめからやり直す
+            中断して最初からやり直す
           </Button>
         )}
       </CardList>

--- a/src/pages/executive/GuestInfo.tsx
+++ b/src/pages/executive/GuestInfo.tsx
@@ -41,6 +41,7 @@ import useErrorHandler from "libs/errorHandler";
 const useStyles = makeStyles((theme) =>
   createStyles({
     tabs: {
+      background: theme.palette.background.default,
       paddingTop: theme.spacing(1),
     },
     list: {

--- a/src/pages/exhibition/ScanHistory.tsx
+++ b/src/pages/exhibition/ScanHistory.tsx
@@ -6,6 +6,8 @@ import {
   ListItemText,
   ListItemIcon,
   Typography,
+  useTheme,
+  Theme,
 } from "@material-ui/core";
 import { createStyles, makeStyles } from "@material-ui/core/styles";
 import { Login, Logout } from "components/MaterialSvgIcons";
@@ -48,6 +50,7 @@ const ScanHistory: React.VFC = () => {
   const classes = useStyles();
   const auth = useContext(AuthContext).val;
   const wristBandPaletteColor = useWristBandPaletteColor();
+  const theme = useTheme<Theme>();
 
   const [logs, setLogs] = useState<ActivityLog[] | null>(null);
 
@@ -103,7 +106,7 @@ const ScanHistory: React.VFC = () => {
                         style={{
                           background: wristBandPaletteColor(
                             log.guest.term.guest_type
-                          ).main,
+                          )[theme.palette.type === "light" ? "main" : "dark"],
                         }}
                       />
                       {log.guest.id}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2239,6 +2239,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/chroma-js@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@types/chroma-js/-/chroma-js-2.1.3.tgz#0b03d737ff28fad10eb884e0c6cedd5ffdc4ba0a"
+  integrity sha512-1xGPhoSGY1CPmXLCBcjVZSQinFjL26vlR8ZqprsBWiFyED4JacJJ9zHhh5aaUXqbY9B37mKQ73nlydVAXmr1+g==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -4096,6 +4101,13 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
+chroma-js@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-2.1.2.tgz#1075cb9ae25bcb2017c109394168b5cf3aa500ec"
+  integrity sha512-ri/ouYDWuxfus3UcaMxC1Tfp3IE9K5iQzxc2hSxbBRVNQFut1UuGAsZmiAf2mOUubzGJwgMSv9lHg+XqLaz1QQ==
+  dependencies:
+    cross-env "^6.0.3"
+
 chrome-trace-event@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4"
@@ -4516,6 +4528,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+cross-env@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-6.0.3.tgz#4256b71e49b3a40637a0ce70768a6ef5c72ae941"
+  integrity sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==
+  dependencies:
+    cross-spawn "^7.0.0"
 
 cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"


### PR DESCRIPTION
close #78

- 大きな変更
  - ダークテーマをより暗く
  - TopBar がスクロール量に応じて変化するように
  - 展示情報カードの導入
  - [iOS] status bar 変更
- その他変更
  - AppBar と BottomNav の elevation を低く
  - ダークテーマでのリストバンド色を一部修正
  - 滞在状況カードの余白を調整
  - カード順序を exhibition と executive で統一
  - 「はじめからやり直す」ボタンをわかりやすく
  - 端末の設定に応じて light / dark を自動切り替え

いいかんじ～～

| light | dark |
| - | - |
| ![l](https://user-images.githubusercontent.com/33474143/125602730-ed1be6c3-a653-4dab-9e39-21b29f18a39c.png) | ![d](https://user-images.githubusercontent.com/33474143/125602738-a9004d8f-09bb-4775-aa95-1b9825982284.png) |
