### PR TITLE
#87 予約・ゲストのアイコンを変更

### DIFF
--- a/src/components/GuestScan.tsx
+++ b/src/components/GuestScan.tsx
@@ -10,9 +10,8 @@ import {
   ListItemText,
 } from "@material-ui/core";
 import { Alert } from "@material-ui/lab";
-import { CheckCircle } from "@material-ui/icons";
+import { CheckCircle, Face } from "@material-ui/icons";
 import { makeStyles, createStyles } from "@material-ui/core/styles";
-import { WristBand } from "components/MaterialSvgIcons";
 import CardList from "components/CardList";
 import QRScanner from "components/QRScanner";
 import DirectInputModal from "components/DirectInputModal";
@@ -179,7 +178,7 @@ const GuestScan: React.VFC<Props> = (props) => {
                       {checkStatus === "success" ? (
                         <CheckCircle className={classes.successIcon} />
                       ) : (
-                        <WristBand />
+                        <Face />
                       )}
                       {checkStatus === "loading" && (
                         <CircularProgress

--- a/src/components/MaterialSvgIcons.tsx
+++ b/src/components/MaterialSvgIcons.tsx
@@ -8,6 +8,8 @@ const iconPaths = {
     "M9.5,6.5v3h-3v-3H9.5 M11,5H5v6h6V5L11,5z M9.5,14.5v3h-3v-3H9.5 M11,13H5v6h6V13L11,13z M17.5,6.5v3h-3v-3H17.5 M19,5h-6v6 h6V5L19,5z M13,13h1.5v1.5H13V13z M14.5,14.5H16V16h-1.5V14.5z M16,13h1.5v1.5H16V13z M13,16h1.5v1.5H13V16z M14.5,17.5H16V19h-1.5 V17.5z M16,16h1.5v1.5H16V16z M17.5,14.5H19V16h-1.5V14.5z M17.5,17.5H19V19h-1.5V17.5z M22,7h-2V4h-3V2h5V7z M22,22v-5h-2v3h-3v2 H22z M2,22h5v-2H4v-3H2V22z M2,2v5h2V4h3V2H2z",
   WristBand:
     "M20,5H6v1.5H5V5H4C2.9,5,2,5.9,2,7v10c0,1.1,0.9,2,2,2h1v-1.5h1V19h14c1.1,0,2-0.9,2-2V7C22,5.9,21.1,5,20,5z M6,16.5H5V15 h1V16.5z M6,14H5v-1.5h1V14z M6,11.5H5V10h1V11.5z M6,9H5V7.5h1V9z M14,8c1.1,0,2,0.9,2,2c0,1.1-0.9,2-2,2s-2-0.9-2-2 C12,8.9,12.9,8,14,8z M18,16h-8v-1c0-1.3,2.7-2,4-2s4,0.7,4,2V16z",
+  ReservationTicket:
+    "M21,16V5a2,2,0,0,0-2-2H5A2,2,0,0,0,3,5V16a1,1,0,0,1,0,2v1a2,2,0,0,0,2,2H19a2,2,0,0,0,2-2V18a1,1,0,0,1,0-2ZM7,7H17V9H7ZM6,18a1,1,0,1,1,1-1A1,1,0,0,1,6,18Zm1-7h7v2H7Zm2,7a1,1,0,1,1,1-1A1,1,0,0,1,9,18Zm3,0a1,1,0,1,1,1-1A1,1,0,0,1,12,18Zm3,0a1,1,0,1,1,1-1A1,1,0,0,1,15,18Zm3,0a1,1,0,1,1,1-1A1,1,0,0,1,18,18Z",
   CameraOff:
     "M20,4h-3.2L15,2H9L7.2,4H6.8l3.4,3.4C10.7,7.1,11.4,7,12,7c2.8,0,5,2.2,5,5c0,0.6-0.1,1.3-0.4,1.8l5.1,5.1 c0.2-0.3,0.2-0.6,0.2-0.9V6C22,4.9,21.1,4,20,4z M15.2,12c0-1.8-1.4-3.2-3.2-3.2c-0.1,0-0.2,0-0.3,0l3.5,3.5C15.2,12.2,15.2,12.1,15.2,12z M20,20l-4.5-4.5c0,0,0,0,0,0l-1.3-1.3c0,0,0,0,0,0L9.7,9.7c0,0,0,0,0,0L8.5,8.5c0,0,0,0,0,0L5.7,5.7L2.8,2.8L1.4,4.2 l0.9,0.9C2.1,5.4,2,5.7,2,6v12c0,1.1,0.9,2,2,2h13.2l2.6,2.6l1.4-1.4L20,20L20,20z M12,17c-2.8,0-5-2.2-5-5c0-0.6,0.1-1.3,0.4-1.8 l1.5,1.5c0,0.1,0,0.2,0,0.3c0,1.8,1.4,3.2,3.2,3.2c0.1,0,0.2,0,0.3,0l1.5,1.5C13.3,16.9,12.6,17,12,17z",
   Login:
@@ -62,6 +64,9 @@ export const QRScannerIcon: React.VFC<SvgIconProps> = (props) => (
 );
 export const WristBand: React.VFC<SvgIconProps> = (props) => (
   <CustomSvgIcon iconType="WristBand" {...props} />
+);
+export const ReservationTicket: React.VFC<SvgIconProps> = (props) => (
+  <CustomSvgIcon iconType="ReservationTicket" {...props} />
 );
 export const CameraOff: React.VFC<SvgIconProps> = (props) => (
   <CustomSvgIcon iconType="CameraOff" {...props} />

--- a/src/components/MaterialSvgIcons.tsx
+++ b/src/components/MaterialSvgIcons.tsx
@@ -6,8 +6,6 @@ import { SvgIcon, SvgIconProps } from "@material-ui/core";
 const iconPaths = {
   QRScannerIcon:
     "M9.5,6.5v3h-3v-3H9.5 M11,5H5v6h6V5L11,5z M9.5,14.5v3h-3v-3H9.5 M11,13H5v6h6V13L11,13z M17.5,6.5v3h-3v-3H17.5 M19,5h-6v6 h6V5L19,5z M13,13h1.5v1.5H13V13z M14.5,14.5H16V16h-1.5V14.5z M16,13h1.5v1.5H16V13z M13,16h1.5v1.5H13V16z M14.5,17.5H16V19h-1.5 V17.5z M16,16h1.5v1.5H16V16z M17.5,14.5H19V16h-1.5V14.5z M17.5,17.5H19V19h-1.5V17.5z M22,7h-2V4h-3V2h5V7z M22,22v-5h-2v3h-3v2 H22z M2,22h5v-2H4v-3H2V22z M2,2v5h2V4h3V2H2z",
-  WristBand:
-    "M20,5H6v1.5H5V5H4C2.9,5,2,5.9,2,7v10c0,1.1,0.9,2,2,2h1v-1.5h1V19h14c1.1,0,2-0.9,2-2V7C22,5.9,21.1,5,20,5z M6,16.5H5V15 h1V16.5z M6,14H5v-1.5h1V14z M6,11.5H5V10h1V11.5z M6,9H5V7.5h1V9z M14,8c1.1,0,2,0.9,2,2c0,1.1-0.9,2-2,2s-2-0.9-2-2 C12,8.9,12.9,8,14,8z M18,16h-8v-1c0-1.3,2.7-2,4-2s4,0.7,4,2V16z",
   ReservationTicket:
     "M21,16V5a2,2,0,0,0-2-2H5A2,2,0,0,0,3,5V16a1,1,0,0,1,0,2v1a2,2,0,0,0,2,2H19a2,2,0,0,0,2-2V18a1,1,0,0,1,0-2ZM7,7H17V9H7ZM6,18a1,1,0,1,1,1-1A1,1,0,0,1,6,18Zm1-7h7v2H7Zm2,7a1,1,0,1,1,1-1A1,1,0,0,1,9,18Zm3,0a1,1,0,1,1,1-1A1,1,0,0,1,12,18Zm3,0a1,1,0,1,1,1-1A1,1,0,0,1,15,18Zm3,0a1,1,0,1,1,1-1A1,1,0,0,1,18,18Z",
   CameraOff:
@@ -61,9 +59,6 @@ const CustomSvgIcon: React.VFC<CustomSvgIconProps> = (props) => (
 
 export const QRScannerIcon: React.VFC<SvgIconProps> = (props) => (
   <CustomSvgIcon iconType="QRScannerIcon" {...props} />
-);
-export const WristBand: React.VFC<SvgIconProps> = (props) => (
-  <CustomSvgIcon iconType="WristBand" {...props} />
 );
 export const ReservationTicket: React.VFC<SvgIconProps> = (props) => (
   <CustomSvgIcon iconType="ReservationTicket" {...props} />

--- a/src/pages/executive/CheckInScan.tsx
+++ b/src/pages/executive/CheckInScan.tsx
@@ -13,9 +13,9 @@ import {
   Typography,
 } from "@material-ui/core";
 import { Alert } from "@material-ui/lab";
-import { Assignment, CheckCircle, Replay } from "@material-ui/icons";
+import { CheckCircle, Face, Replay } from "@material-ui/icons";
 import { createStyles, makeStyles } from "@material-ui/core/styles";
-import { WristBand } from "components/MaterialSvgIcons";
+import { ReservationTicket } from "components/MaterialSvgIcons";
 import CardList from "components/CardList";
 import QRScanner from "components/QRScanner";
 import DirectInputModal from "components/DirectInputModal";
@@ -339,7 +339,7 @@ const CheckInScan: React.VFC = () => {
                       {rsvCheckStatus === "success" ? (
                         <CheckCircle className={classes.successIcon} />
                       ) : (
-                        <Assignment />
+                        <ReservationTicket />
                       )}
                       {rsvCheckStatus === "loading" && (
                         <CircularProgress
@@ -365,7 +365,7 @@ const CheckInScan: React.VFC = () => {
                   </ListItem>
                   <ListItem disabled={activeScanner !== "guest"}>
                     <ListItemIcon>
-                      <WristBand />
+                      <Face />
                     </ListItemIcon>
                     <ListItemText
                       primary={latestGuestId ? latestGuestId : "-"}

--- a/src/pages/executive/GuestInfo.tsx
+++ b/src/pages/executive/GuestInfo.tsx
@@ -13,9 +13,9 @@ import {
   Typography,
 } from "@material-ui/core";
 import { Alert } from "@material-ui/lab";
-import { AccessTime, Assignment } from "@material-ui/icons";
 import { createStyles, makeStyles } from "@material-ui/core/styles";
-import { WristBand } from "components/MaterialSvgIcons";
+import { AccessTime, Face } from "@material-ui/icons";
+import { ReservationTicket } from "components/MaterialSvgIcons";
 import ActivityLogTimeline from "components/ActivityLogTimeline";
 import CardList from "components/CardList";
 import QRScanner from "components/QRScanner";
@@ -321,7 +321,7 @@ const GuestInfo: React.VFC = () => {
                     <List>
                       <ListItem>
                         <ListItemIcon>
-                          <WristBand />
+                          <Face />
                         </ListItemIcon>
                         <ListItemText
                           primary={
@@ -478,7 +478,7 @@ const PrivateInfoList: React.VFC<{
     <List>
       <ListItem>
         <ListItemIcon>
-          <Assignment />
+          <ReservationTicket />
         </ListItemIcon>
         <ListItemText primary={rsvId} secondary="予約 ID" />
       </ListItem>


### PR DESCRIPTION
close #87 

| after | before |
| - | - |
| ![image](https://user-images.githubusercontent.com/33474143/127528307-5d076ebc-2e14-4858-9fba-1972cca9b7a1.png) | ![image](https://user-images.githubusercontent.com/33474143/127528253-0f9ded82-e633-446c-87be-060b4825e922.png) |

## 予約アイコン

`Assignment` -> `ReservationTicket`

- 実際に来場者が提示する予約チケットを表現
- ドットの切り取り線だいすき

## ゲストアイコン

`WristBand` -> `Face`

- チケットとの混同を避けるため、リストバンドをやめた（そもそもリストバンドに見えん）
- 来場者「個人」への帰属を表現
