### PR TITLE
#215 scrollTop が壊れていたのを修正

### DIFF
--- a/src/components/LayoutWrapper.tsx
+++ b/src/components/LayoutWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren, useEffect } from "react";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import { Theme, ThemeProvider, useTheme } from "@material-ui/core";
 import { ThemeContextProvider, useThemeMode } from "libs/themeMode";
 import { TitleContextProvider } from "libs/title";
@@ -57,11 +57,11 @@ const SyncBackgroundColor: React.VFC<PropsWithChildren<unknown>> = ({
 };
 
 const ScrollTop: React.VFC<PropsWithChildren<unknown>> = ({ children }) => {
-  const history = useHistory();
+  const location = useLocation();
 
   useEffect(() => {
     document.documentElement.scrollTo(0, 0);
-  }, [history.location]);
+  }, [location]);
 
   // eslint-disable-next-line react/jsx-no-useless-fragment
   return <>{children}</>;


### PR DESCRIPTION
close #215

React は deps を `Object.is` (の polyfill) で比較しているはずで、 ~~これで直るのは意味がわからない~~

~~けど直ったので PR（こっわ）~~

↓答え

> locationはURLが変わると新しいオブジェクトが作られるのに対して、historyは常に同じオブジェクトであるということです。すなわち、URLが変わってもuseHistoryから返されるhistoryは常に同じオブジェクトです。
[react\-routerで現在のlocationを取得する2種類の方法の使い分け方 \- uhyo/blog](https://blog.uhy.ooo/entry/2020-06-10/react-router-location/#history%E3%81%AF%E5%B8%B8%E3%81%AB%E5%90%8C%E3%81%98%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%A7%E3%81%82%E3%82%8B)


- [React Hooksのメモ化のための第二引数の配列にオブジェクトを突っ込んだときの挙動について \- ひと夏の技術](https://tech-1natsu.hatenablog.com/entry/2019/02/14/214816)
- [等価性の比較と同一性 \- JavaScript \| MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Equality_comparisons_and_sameness#a_model_for_understanding_equality_comparisons)
- [react\-routerで現在のlocationを取得する2種類の方法の使い分け方 \- uhyo/blog](https://blog.uhy.ooo/entry/2020-06-10/react-router-location/)
