### PR TITLE
#178 react-qr-reader による out of memory の暫定的な解決

### DIFF
--- a/src/components/QRScanner.tsx
+++ b/src/components/QRScanner.tsx
@@ -127,6 +127,7 @@ const QRScanner: React.VFC<QRScannerProps> = ({
   >("loading");
   const [showQrReader, setShowQrReader] = useState(true);
   const [timeoutId, setTimeoutId] = useState<number | null>(null);
+  const [qrReaderMount, setQrReaderMount] = useState(false);
 
   useEffect(() => {
     if (!showQrReader) {
@@ -138,6 +139,21 @@ const QRScanner: React.VFC<QRScannerProps> = ({
   useEffect(() => {
     setLastRead(null);
   }, [resetKey]);
+
+  // out of memory の対策として、5 分ごとに react-qr-reader を unmount して、直後に mount している
+  // Chrome: out of memory due to web worker. Chrome not kicking off GC · Issue #205 · JodusNodus/react-qr-reader
+  // https://github.com/JodusNodus/react-qr-reader/issues/205
+  useEffect(() => {
+    const unmountQrReader = () => {
+      setQrReaderMount(false);
+      setScannerStatus("loading");
+    };
+    const intervalId = window.setInterval(unmountQrReader, 5 * 60 * 1000);
+    return () => window.clearInterval(intervalId);
+  }, []);
+  useEffect(() => {
+    if (!qrReaderMount) setQrReaderMount(true);
+  }, [qrReaderMount]);
 
   const getBorderClassName = (color: StatusColor | undefined): string => {
     switch (color) {
@@ -210,7 +226,7 @@ const QRScanner: React.VFC<QRScannerProps> = ({
             )}
           </div>
         )}
-        {showQrReader && (
+        {showQrReader && qrReaderMount && (
           <QrReader
             onScan={onScan}
             onError={errorHandler}


### PR DESCRIPTION
fix #178 

react-qr-reader を unmount した直後に再び mount することで `componentDidMount` を呼び、worker を作り直すことで暫定的な解決策とした
参考とした Issue ではスキャン回数によって worker を作り直しているが、1時間完全放置でもスキャンが停止することが発覚しているため、**5分間隔** で worker を作り直している

- https://github.com/JodusNodus/react-qr-reader/issues/205
- [筑駒文化祭入場管理システム "siesta" 開発・運営記 \- Qiita](https://qiita.com/ret2home/items/9806d073122dd5e7e873)

### english ver

The temporary solution is to unmount the react-qr-reader and then mount it again to call `componentDidMount` to recreate the worker.
In the issue I referred to, the worker is rebuilt according to the number of scans, but since it was discovered that scans stop even if the system is left completely unattended for an hour, the worker is rebuilt at **5 minute intervals**.